### PR TITLE
Add Open Graph meta keys/values to fix preview on social media

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -15,6 +15,11 @@
     <link rel="manifest" href="images/favicon/site.webmanifest">
     <link rel="mask-icon" href="images/favicon/safari-pinned-tab.svg" color="#5bbad5">
 
+    <meta property="og:title" content="FabadaConf 2018" />
+    <meta property="og:image" content="images/logo.png"/>
+    <meta property="og:description" content="Fabada Conference: Xixón 2018" />
+    <meta property="og:url" content="http://www.fabadaconf.com"/>
+
     <title><%= current_page.data.title %></title>
 
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,800" rel="stylesheet">


### PR DESCRIPTION
Add Open Graph data to fix preview on social media, with this tags any shared link will show our logo as image and simple info as link/description